### PR TITLE
Properly handle long comments

### DIFF
--- a/bot/embed.go
+++ b/bot/embed.go
@@ -1,0 +1,20 @@
+package bot
+
+import "github.com/andersfylling/disgord"
+
+// See https://discord.com/developers/docs/resources/channel#embed-limits
+const (
+	titleCharLimit       = 256
+	descriptionCharLimit = 2048
+	fieldCountLimit      = 25
+	fieldNameCharLimit   = 256
+	fieldValueCharLimit  = 1024
+	footerTextCharLimit  = 2048
+	authorNameCharLimit  = 256
+)
+
+// EmbedDescriptionTooLong checks whether the given embed has description longer than the acceptable
+// limit.
+func EmbedDescriptionTooLong(embed *disgord.Embed) bool {
+	return len(embed.Description) > descriptionCharLimit
+}

--- a/comment.go
+++ b/comment.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 	"time"
@@ -20,6 +21,10 @@ var (
 	spoilerContentCls  = "spoiler-content"
 	spoilerSelec       = cascadia.MustCompile("." + spoilerContentCls)
 )
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
 
 const timedMsgTTL = 20 * time.Second
 
@@ -67,12 +72,16 @@ func handleCommentURL(ctx bot.Context, commentURL, commentID string) {
 		return
 	}
 
-	msg, err := ctx.Send(embed)
-	if restErr, ok := err.(*disgord.ErrRest); ok {
-		if strings.Contains(restErr.Suggestion, "Embed size exceeds maximum size") {
-			ctx.SendTimed(timedMsgTTL, "Comment too long :(")
+	if bot.EmbedDescriptionTooLong(embed) {
+		if rand.Intn(20) == 0 {
+			embed.Description = "I have discovered this truly marvelous comment, which this " +
+				"embed is too narrow to contain."
+		} else {
+			embed.Description = "The comment is too large to display."
 		}
 	}
+
+	msg, err := ctx.Send(embed)
 	if err != nil {
 		ctx.Logger.Error(fmt.Errorf("Error sending comment preview: %w", err))
 		return


### PR DESCRIPTION
The message "Embed size exceeds maximum size of 6000" (which is the current check) is only returned when the total size exceeded 6000 (I think). If the embed description exceeds 2048 chars, the returned error has no suggestion.

It's simple enough to check against the 2048 limit before sending.

This should be good enough until preview is added for comments, if that happens.