### PR TITLE
Fix comment revision fetching

### DIFF
--- a/fetch/blog.go
+++ b/fetch/blog.go
@@ -108,7 +108,8 @@ func (f *Fetcher) Comment(
 	url string,
 	commentID string,
 ) (revisionCount int, getter CommentInfoGetter, err error) {
-	doc, err := f.FetchPageBrowser(ctx, url)
+	client := newBrowserScraperClient()
+	doc, err := f.FetchPageWithClient(ctx, url, client)
 	if err != nil {
 		return
 	}
@@ -146,7 +147,7 @@ func (f *Fetcher) Comment(
 				"Expected revision between 1 and %v, got %v", base.RevisionCount, revision)
 		}
 		if _, ok := cache[revision]; !ok {
-			doc, err := f.FetchCommentRevision(ctx, commentID, revision, csrf)
+			doc, err := f.FetchCommentRevision(ctx, commentID, revision, csrf, client)
 			if err != nil {
 				return nil, err
 			}

--- a/fetch/blog_test.go
+++ b/fetch/blog_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -75,12 +76,19 @@ const commentRevFmt = `<div class="ttypography"><p>comment revision %v</p></div>
 
 func testParseComment(t *testing.T, filename string, commentID string, want *CommentInfo) {
 	f := Fetcher{
-		FetchPageBrowser: pageFetcherFor(filename, "testurl"),
-		FetchCommentRevision: func(_ context.Context, gotCommentID string, revision int, _ string) (*goquery.Document, error) {
+		FetchPageWithClient: pageFetcherWithClientFor(filename, "testurl"),
+		FetchCommentRevision: func(
+			_ context.Context,
+			gotCommentID string,
+			revision int,
+			_ string,
+			_ *http.Client,
+		) (*goquery.Document, error) {
 			if gotCommentID != commentID {
 				t.Fatalf("got %v, want %v", gotCommentID, commentID)
 			}
-			return goquery.NewDocumentFromReader(strings.NewReader(fmt.Sprintf(commentRevFmt, revision)))
+			return goquery.NewDocumentFromReader(
+				strings.NewReader(fmt.Sprintf(commentRevFmt, revision)))
 		},
 	}
 	gotRevCnt, getter, err := f.Comment(context.Background(), "testurl", commentID)

--- a/fetch/testutil_test.go
+++ b/fetch/testutil_test.go
@@ -18,7 +18,10 @@ func loadHtmlTestFile(filename string) (*goquery.Document, error) {
 	return goquery.NewDocumentFromReader(f)
 }
 
-func pageFetcherFor(filename string, wantURL string) func(context.Context, string) (*goquery.Document, error) {
+func pageFetcherFor(
+	filename string,
+	wantURL string,
+) func(context.Context, string) (*goquery.Document, error) {
 	return func(_ context.Context, url string) (*goquery.Document, error) {
 		if url != wantURL {
 			return nil, fmt.Errorf("got %v, want %v", url, wantURL)
@@ -27,7 +30,10 @@ func pageFetcherFor(filename string, wantURL string) func(context.Context, strin
 	}
 }
 
-func pageFetcherWithClientFor(filename string, wantURL string) func(context.Context, string, *http.Client) (*goquery.Document, error) {
+func pageFetcherWithClientFor(
+	filename string,
+	wantURL string,
+) func(context.Context, string, *http.Client) (*goquery.Document, error) {
 	return func(_ context.Context, url string, _ *http.Client) (*goquery.Document, error) {
 		if url != wantURL {
 			return nil, fmt.Errorf("got %v, want %v", url, wantURL)

--- a/fetch/testutil_test.go
+++ b/fetch/testutil_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/PuerkitoBio/goquery"
@@ -19,6 +20,15 @@ func loadHtmlTestFile(filename string) (*goquery.Document, error) {
 
 func pageFetcherFor(filename string, wantURL string) func(context.Context, string) (*goquery.Document, error) {
 	return func(_ context.Context, url string) (*goquery.Document, error) {
+		if url != wantURL {
+			return nil, fmt.Errorf("got %v, want %v", url, wantURL)
+		}
+		return loadHtmlTestFile(filename)
+	}
+}
+
+func pageFetcherWithClientFor(filename string, wantURL string) func(context.Context, string, *http.Client) (*goquery.Document, error) {
+	return func(_ context.Context, url string, _ *http.Client) (*goquery.Document, error) {
 		if url != wantURL {
 			return nil, fmt.Errorf("got %v, want %v", url, wantURL)
 		}


### PR DESCRIPTION
Fix for broken comment revisions.
Broke because #30 started clearing session IDs after each fetch.