### PR TITLE
Submission snippet improvements

### DIFF
--- a/bot/messager.go
+++ b/bot/messager.go
@@ -12,7 +12,7 @@ import (
 // Messager wraps a disgord.Session to do message stuff. Used by widgets.
 // Disgord's fluent interface is nice to use but such a pain to mock. Maybe switch to discordgo.
 type Messager interface {
-	Send(ctx context.Context, channelID disgord.Snowflake, content string, embed *disgord.Embed) (*disgord.Message, error)
+	Send(ctx context.Context, channelID disgord.Snowflake, params *disgord.CreateMessageParams) (*disgord.Message, error)
 	Edit(ctx context.Context, msg *disgord.Message, content string, embed *disgord.Embed) (*disgord.Message, error)
 	React(ctx context.Context, msg *disgord.Message, reaction string) error
 	Unreact(ctx context.Context, msg *disgord.Message, reaction string) error
@@ -28,10 +28,9 @@ type disgordMessager struct {
 func (m *disgordMessager) Send(
 	ctx context.Context,
 	channelID disgord.Snowflake,
-	content string,
-	embed *disgord.Embed,
+	params *disgord.CreateMessageParams,
 ) (*disgord.Message, error) {
-	return m.session.WithContext(ctx).SendMsg(channelID, content, embed)
+	return m.session.WithContext(ctx).SendMsg(channelID, params)
 }
 
 func (m *disgordMessager) Edit(

--- a/bot/mock_bot/mock_messager.go
+++ b/bot/mock_bot/mock_messager.go
@@ -92,18 +92,18 @@ func (mr *MockMessagerMockRecorder) React(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // Send mocks base method.
-func (m *MockMessager) Send(arg0 context.Context, arg1 snowflake.Snowflake, arg2 string, arg3 *disgord.Embed) (*disgord.Message, error) {
+func (m *MockMessager) Send(arg0 context.Context, arg1 snowflake.Snowflake, arg2 *disgord.CreateMessageParams) (*disgord.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Send", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*disgord.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockMessagerMockRecorder) Send(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockMessagerMockRecorder) Send(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockMessager)(nil).Send), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockMessager)(nil).Send), arg0, arg1, arg2)
 }
 
 // Unreact mocks base method.

--- a/bot/widget.go
+++ b/bot/widget.go
@@ -30,6 +30,7 @@ type Pages struct {
 	Get   func(pageNum int) *Page
 	Total int
 	First int
+	Files []disgord.CreateMessageFileParams
 }
 
 // MsgCallbackType is the callback function type invoked on message create.
@@ -155,9 +156,13 @@ func (w *widget) run(ctx context.Context, channelID disgord.Snowflake) error {
 	w.currentReacts = make(map[string]bool)
 
 	// Send page to show first, add reacts
+	params := &disgord.CreateMessageParams{
+		Content: w.currentPage.Default.Content,
+		Embed:   w.currentPage.Default.Embed,
+		Files:   w.params.Pages.Files,
+	}
 	var err error
-	w.msg, err = w.messager.Send(
-		w.ctx, channelID, w.currentPage.Default.Content, w.currentPage.Default.Embed)
+	w.msg, err = w.messager.Send(w.ctx, channelID, params)
 	if err != nil {
 		return err
 	}

--- a/bot/widget_test.go
+++ b/bot/widget_test.go
@@ -133,8 +133,9 @@ type messagerCalls struct {
 }
 
 func (c *messagerCalls) send(content string, embed *disgord.Embed) *gomock.Call {
+	params := &disgord.CreateMessageParams{Content: content, Embed: embed}
 	return c.messager.EXPECT().
-		Send(activeContextMatcher{}, testChannelID, content, embed).
+		Send(activeContextMatcher{}, testChannelID, params).
 		Return(testMsg, nil)
 }
 

--- a/fetch/submission.go
+++ b/fetch/submission.go
@@ -44,7 +44,9 @@ func (f *Fetcher) Submission(ctx context.Context, url string) (*SubmissionInfo, 
 	var s SubmissionInfo
 	infoRow := doc.FindMatcher(infoRowSelec).Eq(1).FindMatcher(infoCellSelec)
 
-	s.Type = strings.TrimSuffix(strings.TrimSpace(infoRow.Eq(1).Contents().First().Text()), ":")
+	s.ID = infoRow.Eq(0).Text()
+	s.ParticipantType = strings.TrimSuffix(
+		strings.TrimSpace(infoRow.Eq(1).Contents().First().Text()), ":")
 	authorCell := infoRow.Eq(1)
 	if s.AuthorGhost = parseGhost(authorCell); s.AuthorGhost == "" {
 		authors := parseAuthors(authorCell)

--- a/fetch/submission_test.go
+++ b/fetch/submission_test.go
@@ -28,36 +28,39 @@ func testParseSubmission(t *testing.T, filename string, want *SubmissionInfo) {
 func TestParseSubmission(t *testing.T) {
 	t.Run("solo", func(t *testing.T) {
 		want := &SubmissionInfo{
+			ID: "66681791",
 			Author: &SubmissionInfoAuthor{
 				Handle: "AM.EM.U4EAC19012",
 				Color:  colorClsMap["user-black"],
 			},
-			Problem:  "1267B",
-			Language: "Python 3",
-			Verdict:  "Wrong answer on test 1",
-			Type:     "Practice",
-			SentTime: time.Date(2019, 12, 12, 13, 23, 43, 0, time.UTC),
-			URL:      "testurl",
-			Content:  "x=input()\n",
+			Problem:         "1267B",
+			Language:        "Python 3",
+			Verdict:         "Wrong answer on test 1",
+			ParticipantType: "Practice",
+			SentTime:        time.Date(2019, 12, 12, 13, 23, 43, 0, time.UTC),
+			URL:             "testurl",
+			Content:         "x=input()\n",
 		}
 		testParseSubmission(t, "contest_1267_submission_66681791.html", want)
 	})
 
 	t.Run("ghost", func(t *testing.T) {
 		want := &SubmissionInfo{
-			AuthorGhost: "SPb ITMO: Reduce (Korobkov, Ovechkin, Poduremennykh)",
-			Problem:     "1267A",
-			Language:    "Unknown",
-			Verdict:     "Accepted",
-			Type:        "Virtual",
-			SentTime:    time.Date(2019, 12, 02, 11, 25, 44, 0, time.UTC),
-			URL:         "testurl",
+			ID:              "66173991",
+			AuthorGhost:     "SPb ITMO: Reduce (Korobkov, Ovechkin, Poduremennykh)",
+			Problem:         "1267A",
+			Language:        "Unknown",
+			Verdict:         "Accepted",
+			ParticipantType: "Virtual",
+			SentTime:        time.Date(2019, 12, 02, 11, 25, 44, 0, time.UTC),
+			URL:             "testurl",
 		}
 		testParseSubmission(t, "contest_1267_submission_66173991.html", want)
 	})
 
 	t.Run("team", func(t *testing.T) {
 		want := &SubmissionInfo{
+			ID: "66109629",
 			AuthorTeam: &SubmissionInfoTeam{
 				Name: "RednBlack Tree Team",
 				Authors: []*SubmissionInfoAuthor{
@@ -66,12 +69,12 @@ func TestParseSubmission(t *testing.T) {
 					{Handle: "Sadykhzadeh", Color: colorClsMap["user-cyan"]},
 				},
 			},
-			Problem:  "1267L",
-			Language: "GNU C++17",
-			Verdict:  "Wrong answer on test 1",
-			Type:     "Contestant",
-			SentTime: time.Date(2019, 12, 01, 9, 18, 50, 0, time.UTC),
-			URL:      "testurl",
+			Problem:         "1267L",
+			Language:        "GNU C++17",
+			Verdict:         "Wrong answer on test 1",
+			ParticipantType: "Contestant",
+			SentTime:        time.Date(2019, 12, 01, 9, 18, 50, 0, time.UTC),
+			URL:             "testurl",
 			Content: `#include <bits/stdc++.h>
 
 using namespace std;
@@ -96,16 +99,17 @@ int main()
 
 	t.Run("noTimeAndMemory", func(t *testing.T) {
 		want := &SubmissionInfo{
+			ID: "90658946",
 			Author: &SubmissionInfoAuthor{
 				Handle: "frodakcin",
 				Color:  colorClsMap["user-red"],
 			},
-			Problem:  "1386A",
-			Language: "GNU C++11",
-			Verdict:  "Perfect result: 100 points",
-			Type:     "Practice",
-			SentTime: time.Date(2020, 8, 22, 6, 8, 49, 0, time.UTC),
-			URL:      "testurl",
+			Problem:         "1386A",
+			Language:        "GNU C++11",
+			Verdict:         "Perfect result: 100 points",
+			ParticipantType: "Practice",
+			SentTime:        time.Date(2020, 8, 22, 6, 8, 49, 0, time.UTC),
+			URL:             "testurl",
 			Content: `#include <cstdio>
 #include <cassert>
 

--- a/fetch/types.go
+++ b/fetch/types.go
@@ -75,18 +75,20 @@ type SubmissionInfoTeam struct {
 
 // SubmissionInfo contains submission information.
 type SubmissionInfo struct {
+	ID string
+
 	// These are mutually exclusive.
 	Author      *SubmissionInfoAuthor
 	AuthorTeam  *SubmissionInfoTeam
 	AuthorGhost string
 
-	Problem  string
-	Language string
-	Verdict  string
-	Type     string
-	SentTime time.Time
-	Content  string
-	URL      string
+	Problem         string
+	Language        string
+	Verdict         string
+	ParticipantType string
+	SentTime        time.Time
+	Content         string
+	URL             string
 }
 
 // ProfileInfo contains profile information.

--- a/main.go
+++ b/main.go
@@ -21,14 +21,15 @@ var logger = logrus.New()
 
 func init() {
 	logger.Formatter.(*logrus.TextFormatter).FullTimestamp = true
-	if token == "" {
-		logger.Fatal("TOKEN env var missing")
-	}
 }
 
 func main() {
 	serverCountFeature := flag.Bool("scf", false, "install the server count feature")
 	flag.Parse()
+
+	if token == "" {
+		logger.Fatal("TOKEN env var missing")
+	}
 
 	logger.Info("------------ CFSpy starting ------------")
 	defer logger.Info("------------ CFSpy stopped ------------")

--- a/respondutil.go
+++ b/respondutil.go
@@ -33,15 +33,17 @@ func prepareCallbacks(ctx *bot.Context) (
 func respondWithOnePagePreview(
 	ctx *bot.Context,
 	page *bot.Page,
+	files ...disgord.CreateMessageFileParams,
 ) error {
 	getPage := func(int) *bot.Page { return page }
-	return respondWithMultiPagePreview(ctx, getPage, 1)
+	return respondWithMultiPagePreview(ctx, getPage, 1, files...)
 }
 
 func respondWithMultiPagePreview(
 	ctx *bot.Context,
 	getPage func(int) *bot.Page,
 	numPages int,
+	files ...disgord.CreateMessageFileParams,
 ) error {
 	msgCallback, delCallback, allowOp := prepareCallbacks(ctx)
 	return ctx.SendWidget(&bot.WidgetParams{
@@ -49,6 +51,7 @@ func respondWithMultiPagePreview(
 			Get:   getPage,
 			Total: numPages,
 			First: numPages,
+			Files: files,
 		},
 		MsgCallback: msgCallback,
 		Lifetime:    time.Minute,

--- a/submission.go
+++ b/submission.go
@@ -99,7 +99,8 @@ func handleSubmissionURL(ctx *bot.Context, match *fetch.SubmissionURLMatch) {
 		return
 	}
 
-	content, embed, file, err := makeResponse(submissionInfo, match.LineBegin, match.LineEnd)
+	content, embed, file, err :=
+		makeSubmissionResponse(submissionInfo, match.LineBegin, match.LineEnd)
 	if err != nil {
 		ctx.Logger.Error(err)
 		respondWithError(ctx, err)
@@ -117,7 +118,7 @@ func handleSubmissionURL(ctx *bot.Context, match *fetch.SubmissionURLMatch) {
 	}
 }
 
-func makeResponse(
+func makeSubmissionResponse(
 	info *fetch.SubmissionInfo,
 	lineBegin int,
 	lineEnd int,

--- a/submission.go
+++ b/submission.go
@@ -107,9 +107,10 @@ func handleSubmissionURL(ctx *bot.Context, match *fetch.SubmissionURLMatch) {
 		} else {
 			// The file size is never expected to be too large as Codeforces source limit is 64KB
 			// and Discord limit is 8MB.
-			reader, filename := makeReaderAndFilename(
-				snippet, submissionInfo.Language, submissionInfo.ID)
-			file = &disgord.CreateMessageFileParams{Reader: reader, FileName: filename}
+			file = &disgord.CreateMessageFileParams{
+				Reader:   strings.NewReader(snippet),
+				FileName: makeFilename(submissionInfo.ID, submissionInfo.Language),
+			}
 		}
 	}
 
@@ -200,13 +201,12 @@ func makeContent(snippet, language string) string {
 	return "```" + languageNameToExt[language] + "\n" + snippet + "```"
 }
 
-func makeReaderAndFilename(snippet, language, id string) (*strings.Reader, string) {
+func makeFilename(id, language string) string {
 	var ext string
 	if ext = languageNameToExt[language]; ext == "" {
 		ext = "txt"
 	}
-	filename := id + "_snippet." + ext
-	return strings.NewReader(snippet), filename
+	return id + "_snippet." + ext
 }
 
 func clamp(x, low, high int) int {

--- a/submission_test.go
+++ b/submission_test.go
@@ -128,7 +128,8 @@ func TestMakeSubmissionResponse(t *testing.T) {
 			wantEmbed: newWantEmbed(
 				"Submission for 4321Z by author",
 				"✅ Accepted • Contestant • Go",
-				testAuthor.Color),
+				testAuthor.Color,
+			),
 		},
 		{
 			name: "summaryPerfectResult",

--- a/submission_test.go
+++ b/submission_test.go
@@ -108,7 +108,7 @@ func testContentLines(start, end int) string {
 	return strings.Join(strings.Split(testContent, "\n")[start-1:end], "\n")
 }
 
-func TestMakeResponse(t *testing.T) {
+func TestMakeSubmissionResponse(t *testing.T) {
 	type file struct{ name, content string }
 	tests := []struct {
 		name string

--- a/submission_test.go
+++ b/submission_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andersfylling/disgord"
+	"github.com/go-test/deep"
+	"github.com/meooow25/cfspy/fetch"
+)
+
+var (
+	testTime   = time.Now()
+	testAuthor = &fetch.SubmissionInfoAuthor{
+		Handle: "author",
+		Color:  0x123456,
+	}
+	testAuthorTeam = &fetch.SubmissionInfoTeam{
+		Name: "worst team ever",
+		Authors: []*fetch.SubmissionInfoAuthor{
+			{Handle: "member1", Color: 0x010203},
+			{Handle: "member2", Color: 0x030201},
+		},
+	}
+	testAuthorGhost     = "wooooo"
+	testContent         string
+	testContentLongLine = strings.Repeat("a", 5000)
+)
+
+func init() {
+	var contentBuilder strings.Builder
+	for i := 0; i < 200; i++ {
+		contentBuilder.WriteString(fmt.Sprintf("Line %v\n", i+1))
+	}
+	contentBuilder.WriteString("\n")
+	for i := 200; i < 400; i++ {
+		contentBuilder.WriteString(fmt.Sprintf("Line %v\n", i+1))
+	}
+	testContent = contentBuilder.String()
+}
+
+func newSubmissionInfo(opts ...func(*fetch.SubmissionInfo)) *fetch.SubmissionInfo {
+	// defaults: author, language, verdict, content
+	info := &fetch.SubmissionInfo{
+		ID:              "998244353",
+		Author:          testAuthor,
+		Problem:         "4321Z",
+		Language:        "Go",
+		Verdict:         "Verdict",
+		ParticipantType: "Contestant",
+		SentTime:        testTime,
+		Content:         testContent,
+		URL:             "testUrl",
+	}
+	for _, opt := range opts {
+		opt(info)
+	}
+	return info
+}
+
+func verdict(v string) func(*fetch.SubmissionInfo) {
+	return func(info *fetch.SubmissionInfo) {
+		info.Verdict = v
+	}
+}
+
+func authorTeam(a *fetch.SubmissionInfoTeam) func(*fetch.SubmissionInfo) {
+	return func(info *fetch.SubmissionInfo) {
+		info.Author = nil
+		info.AuthorTeam = a
+		info.AuthorGhost = ""
+	}
+}
+
+func authorGhost(a string) func(*fetch.SubmissionInfo) {
+	return func(info *fetch.SubmissionInfo) {
+		info.Author = nil
+		info.AuthorTeam = nil
+		info.AuthorGhost = a
+	}
+}
+
+func language(l string) func(*fetch.SubmissionInfo) {
+	return func(info *fetch.SubmissionInfo) {
+		info.Language = l
+	}
+}
+
+func content(c string) func(*fetch.SubmissionInfo) {
+	return func(info *fetch.SubmissionInfo) {
+		info.Content = c
+	}
+}
+
+func newWantEmbed(title, description string, color int) *disgord.Embed {
+	return &disgord.Embed{
+		Title:       title,
+		Description: description,
+		URL:         "testUrl",
+		Timestamp:   disgord.Time{Time: testTime},
+		Color:       color,
+	}
+}
+
+func testContentLines(start, end int) string {
+	return strings.Join(strings.Split(testContent, "\n")[start-1:end], "\n")
+}
+
+func TestMakeResponse(t *testing.T) {
+	tests := []struct {
+		name string
+
+		info      *fetch.SubmissionInfo
+		lineBegin int
+		lineEnd   int
+
+		wantContent string
+		wantEmbed   *disgord.Embed
+		wantFile    *disgord.CreateMessageFileParams
+		wantErr     error
+	}{
+		{
+			name: "summaryAccepted",
+			info: newSubmissionInfo(verdict("Accepted")),
+			wantEmbed: newWantEmbed(
+				"Submission for 4321Z by author",
+				"✅ Accepted • Contestant • Go",
+				testAuthor.Color),
+		},
+		{
+			name: "summaryPerfectResult",
+			info: newSubmissionInfo(verdict("Perfect result: 100 points")),
+			wantEmbed: newWantEmbed(
+				"Submission for 4321Z by author",
+				"✅ Perfect result: 100 points • Contestant • Go",
+				testAuthor.Color,
+			),
+		},
+		{
+			name: "summaryNotAccepted",
+			info: newSubmissionInfo(verdict("Any verdict excepted accepted")),
+			wantEmbed: newWantEmbed(
+				"Submission for 4321Z by author",
+				"Any verdict excepted accepted • Contestant • Go",
+				testAuthor.Color,
+			),
+		},
+		{
+			name: "summaryAuthorTeam",
+			info: newSubmissionInfo(authorTeam(testAuthorTeam)),
+			wantEmbed: newWantEmbed(
+				"Submission for 4321Z by worst team ever: member1, member2",
+				"Verdict • Contestant • Go",
+				teamColor,
+			),
+		},
+		{
+			name: "summaryAuthorGhost",
+			info: newSubmissionInfo(authorGhost("I'm a ghost"), language("Unknown")),
+			wantEmbed: newWantEmbed(
+				"Submission for 4321Z by I'm a ghost 👻",
+				"Verdict • Contestant • Unknown language",
+				ghostColor,
+			),
+		},
+		{
+			name:        "snippetShort",
+			info:        newSubmissionInfo(),
+			lineBegin:   12,
+			lineEnd:     15,
+			wantContent: "```go\n" + testContentLines(12, 15) + "```",
+		},
+		{
+			name:        "snippetShortLineNumsClamped",
+			info:        newSubmissionInfo(content("code")),
+			lineBegin:   -100,
+			lineEnd:     100,
+			wantContent: "```go\ncode```",
+		},
+		{
+			name:        "snippetShortNoExtMapped",
+			info:        newSubmissionInfo(language("HolyC")),
+			lineBegin:   12,
+			lineEnd:     15,
+			wantContent: "```\n" + testContentLines(12, 15) + "```",
+		},
+		{
+			name:        "snippetShortMaxLines",
+			info:        newSubmissionInfo(),
+			lineBegin:   12,
+			lineEnd:     12 + maxSnippetMsgLines - 1,
+			wantContent: "```go\n" + testContentLines(12, 12+maxSnippetMsgLines-1) + "```",
+		},
+		{
+			name:      "snippetLongMinLines",
+			info:      newSubmissionInfo(),
+			lineBegin: 12,
+			lineEnd:   12 + maxSnippetMsgLines,
+			wantFile: &disgord.CreateMessageFileParams{
+				FileName: "snippet_998244353.go",
+				Reader:   strings.NewReader(testContentLines(12, 12+maxSnippetMsgLines)),
+			},
+		},
+		{
+			name:      "snippetLong",
+			info:      newSubmissionInfo(),
+			lineBegin: 12,
+			lineEnd:   365,
+			wantFile: &disgord.CreateMessageFileParams{
+				FileName: "snippet_998244353.go",
+				Reader:   strings.NewReader(testContentLines(12, 365)),
+			},
+		},
+		{
+			name:      "snippetLongNoExtMapped",
+			info:      newSubmissionInfo(language("HolyC")),
+			lineBegin: 12,
+			lineEnd:   365,
+			wantFile: &disgord.CreateMessageFileParams{
+				FileName: "snippet_998244353.txt",
+				Reader:   strings.NewReader(testContentLines(12, 365)),
+			},
+		},
+		{
+			name:      "snippetLongOneLine",
+			info:      newSubmissionInfo(content(testContentLongLine)),
+			lineBegin: 1,
+			lineEnd:   1,
+			wantFile: &disgord.CreateMessageFileParams{
+				FileName: "snippet_998244353.go",
+				Reader:   strings.NewReader(testContentLongLine),
+			},
+		},
+		{
+			name:      "snippetEmpty",
+			info:      newSubmissionInfo(),
+			lineBegin: 201,
+			lineEnd:   201,
+			wantErr:   errSelectionEmpty,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			content, embed, file, err := makeResponse(test.info, test.lineBegin, test.lineEnd)
+
+			eq := func(a, b interface{}) {
+				if diff := deep.Equal(a, b); diff != nil {
+					t.Fatal(diff)
+				}
+			}
+
+			eq(err, test.wantErr)
+			eq(content, test.wantContent)
+			eq(embed, test.wantEmbed)
+			eq(file, test.wantFile)
+			eq(content, test.wantContent)
+		})
+	}
+}


### PR DESCRIPTION
Discord introduced collapsible file previews a while ago, time to put that to use.
Snippets are now sent as files if they are too large to fit in the body or if they are more than 30 lines long.