### PR TITLE
Language update

### DIFF
--- a/submission.go
+++ b/submission.go
@@ -13,7 +13,7 @@ import (
 )
 
 var languageNameToExt = map[string]string{
-	// Currently available in the filter options on the status page of contests.
+	// Available in the filter options on the status page of contests, as of 2021-10-25.
 	"GNU C11":               "c",
 	"Clang++17 Diagnostics": "cpp",
 	"GNU C++14":             "cpp",


### PR DESCRIPTION
Codeforces supports some new languages, adding them to the map of lang to ext. This is used for syntax highlighted code blocks.